### PR TITLE
210606 Fix: Refactor and include 'as' to component

### DIFF
--- a/src/Shake.js
+++ b/src/Shake.js
@@ -1,6 +1,66 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
 
+const toString = (obj) => {
+  return Object.keys(obj).reduce((acc, next) => {
+    return `${acc}
+			${next} {
+				transform: ${obj[next].transform}
+			}`
+  }, '')
+}
+
+const ShakeComp = styled.div`
+  animation-name: ${(p) => p.shouldShakeDefault && p.shakeKeyframes};
+  animation-duration: ${(p) => p.dur}ms;
+  animation-iteration-count: ${(p) => p.q};
+  display: 'inline-block';
+  transform-origin: ${(p) => p.orig};
+
+  &${(p) => p.trigger} {
+    animation-name: ${(p) => p.shouldShakeWhenTriggered && p.shakeKeyframes};
+    animation-play-state: ${(p) =>
+      p.freez && (!p.fixed ? 'running' : 'paused')};
+    animation: ${(p) => p.fixed && p.fixedStop && 'initial'};
+  }
+
+  animation-play-state: ${(p) =>
+    p.active ? (p.freez && !p.fixed ? 'paused' : 'running') : 'paused'};
+`
+
+const random = (max, min = 0) => {
+  return Math.random() * (max - min) - max / 2
+}
+
+const doKeyframes = (int, max, h, v, r) => {
+  const init = 'translate(0,0) rotate(0)'
+  // el objecto que iremos llenando
+  const kf = {
+    '0%': {
+      transform: init,
+    },
+  }
+
+  // loop con intervalos basados en `int`
+  for (let st = int; st <= max; st += int) {
+    // Numeros aleatorios en cada keyframe
+    const x = random(h)
+    const y = random(v)
+    const rot = random(r)
+
+    kf[`${st}%`] = {
+      transform: `translate(${x}px, ${y}px) rotate(${rot}deg)`,
+    }
+  }
+
+  // Init de las transformaciones en 0% y 100%
+  kf[`${Math.min(max, 100)}%`] = {
+    transform: init,
+  }
+
+  return toString(kf)
+}
+
 const Shake = ({
   h = 5,
   v = 5,
@@ -19,72 +79,30 @@ const Shake = ({
   elem = 'div',
   ...props
 }) => {
-  const random = (max, min = 0) => {
-    return Math.random() * (max - min) - max / 2
-  }
-
-  const doKeyframes = () => {
-    // el objecto que iremos llenando
-    let kf = {}
-    const init = 'translate(0,0) rotate(0)'
-
-    // loop con intervalos basados en `int`
-    for (let st = int; st <= max; st += int) {
-      // Numeros aleatorios en cada keyframe
-      const x = random(h)
-      const y = random(v)
-      const rot = random(r)
-
-      kf[`${st}%`] = {
-        transform: `translate(${x}px, ${y}px) rotate(${rot}deg)`,
-      }
-    }
-
-    // Init de las transformaciones en 0% y 100%
-    kf[`0%`] = kf[`${Math.min(max, 100)}%`] = {
-      transform: init,
-    }
-
-    return kf
-  }
-
   // Creamos los `@keyframes`
-  const kf = doKeyframes()
-
-  const toString = (obj) => {
-    return Object.keys(obj).reduce((acc, next) => {
-      return `${acc}
-			${next} {
-				transform: ${obj[next].transform}
-			}`
-    }, '')
-  }
-
-  const shakeKeyframes = keyframes`${toString(kf)}`
+  const shakeKeyframes = keyframes`${doKeyframes(int, max, h, v, r)}`
   const shouldShakeDefault = fixed || (!fixed && freez)
   const shouldShakeWhenTriggered = !fixed && !freez
 
-  const ShakeComp = styled[elem]`
-    animation-name: ${shouldShakeDefault && shakeKeyframes};
-    animation-duration: ${dur}ms;
-    animation-iteration-count: ${q};
-    display: 'inline-block';
-    transform-origin: ${orig};
-
-    &${trigger} {
-      animation-name: ${shouldShakeWhenTriggered && shakeKeyframes};
-      animation-play-state: ${freez && (!fixed ? 'running' : 'paused')};
-      animation: ${fixed && fixedStop && 'initial'};
-    }
-
-    animation-play-state: ${active
-      ? freez && !fixed
-        ? 'paused'
-        : 'running'
-      : 'paused'};
-  `
-
-  return <ShakeComp {...props}>{props.children}</ShakeComp>
+  return (
+    <ShakeComp
+      as={elem}
+      dur={dur}
+      orig={orig}
+      q={q}
+      freez={freez}
+      fixed={fixed}
+      fixedStop={fixedStop}
+      active={active}
+      trigger={trigger}
+      shakeKeyframes={shakeKeyframes}
+      shouldShakeDefault={shouldShakeDefault}
+      shouldShakeWhenTriggered={shouldShakeWhenTriggered}
+      {...props}
+    >
+      {props.children}
+    </ShakeComp>
+  )
 }
 
 export default Shake


### PR DESCRIPTION
This PR includes the following changes

- Extract functions inside the Shake component (src/Shake.js)
- Add ```as={elem}``` to ShakeComp (src/Shake.js) so that polymorphic prop of ```styled-component``` is used.
    Source: https://styled-components.com/docs/api#as-polymorphic-prop
    This solves issue #10 

The followings are my suggestions
- Extracting functions of ```src/Shake.js``` into other file, such as ```util.js```
- Adding typescript types to this package, or just add it to this package.


I am interested adding typscript types to this package. Never tried one before, but seems quite simple tho.
If you are interested in this too, I can try.

P.S. Also, I kindda thought about translating comments into English, but LOL